### PR TITLE
Add nubit DA backend

### DIFF
--- a/cmd/run_xlayer.go
+++ b/cmd/run_xlayer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xPolygonHermez/zkevm-node/config/apollo"
 	"github.com/0xPolygonHermez/zkevm-node/dataavailability"
 	"github.com/0xPolygonHermez/zkevm-node/dataavailability/datacommittee"
+	"github.com/0xPolygonHermez/zkevm-node/dataavailability/nubit"
 	"github.com/0xPolygonHermez/zkevm-node/etherman"
 	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
 	"github.com/0xPolygonHermez/zkevm-node/event"
@@ -119,6 +120,31 @@ func newDataAvailability(c config.Config, st *state.State, etherman *etherman.Cl
 			dacAddr,
 			pk,
 			dataCommitteeClient.NewFactory(),
+		)
+		if err != nil {
+			return nil, err
+		}
+	case string(dataavailability.DataAvailabilityNubitDA):
+		var (
+			pk  *ecdsa.PrivateKey
+			err error
+		)
+		if isSequenceSender {
+			_, pk, err = etherman.LoadAuthFromKeyStoreXLayer(c.SequenceSender.DAPermitApiPrivateKey.Path, c.SequenceSender.DAPermitApiPrivateKey.Password)
+			if err != nil {
+				return nil, err
+			}
+			log.Infof("from pk %s", crypto.PubkeyToAddress(pk.PublicKey))
+		}
+		dacAddr, err := etherman.GetDAProtocolAddr()
+		if err != nil {
+			return nil, fmt.Errorf("error getting trusted sequencer URI. Error: %v", err)
+		}
+		daBackend, err = nubit.NewNubitDABackend(
+			c.Etherman.URL,
+			dacAddr,
+			pk,
+			&c.DataAvailability,
 		)
 		if err != nil {
 			return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/0xPolygonHermez/zkevm-node/aggregator"
 	"github.com/0xPolygonHermez/zkevm-node/config/types"
+	"github.com/0xPolygonHermez/zkevm-node/dataavailability/nubit"
 	"github.com/0xPolygonHermez/zkevm-node/db"
 	"github.com/0xPolygonHermez/zkevm-node/etherman"
 	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
@@ -102,6 +103,8 @@ type Config struct {
 	SequenceSender sequencesender.Config
 	// Configuration of the aggregator service
 	Aggregator aggregator.Config
+	// Configuration of the NubitDA data availability service
+	DataAvailability nubit.Config
 	// Configuration of the genesis of the network. This is used to known the initial state of the network
 	NetworkConfig NetworkConfig
 	// Configuration of the gas price suggester service

--- a/config/default.go
+++ b/config/default.go
@@ -243,6 +243,15 @@ AggLayerTxTimeout = "5m"
 AggLayerURL = ""
 SequencerPrivateKey = {}
 
+[DataAvailability]
+NubitRpcURL = ""
+NubitModularAppName = ""
+NubitAuthKey = ""
+NubitNamespace = "xlayer"
+NubitMaxBatchesSize = "102400"
+NubitGetProofMaxRetry = "10"
+NubitGetProofWaitPeriod = "5s"
+
 [L2GasPriceSuggester]
 Type = "follower"
 UpdatePeriod = "10s"

--- a/dataavailability/config.go
+++ b/dataavailability/config.go
@@ -6,4 +6,6 @@ type DABackendType string
 const (
 	// DataAvailabilityCommittee is the DAC protocol backend
 	DataAvailabilityCommittee DABackendType = "DataAvailabilityCommittee"
+	// DataAvailabilityNubitDA is the NubitDA protocol backend
+	DataAvailabilityNubitDA DABackendType = "NubitDA"
 )

--- a/dataavailability/nubit/backend.go
+++ b/dataavailability/nubit/backend.go
@@ -1,0 +1,176 @@
+package nubit
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"time"
+
+	daTypes "github.com/0xPolygon/cdk-data-availability/types"
+	polygondatacommittee "github.com/0xPolygonHermez/zkevm-node/etherman/smartcontracts/polygondatacommittee_xlayer"
+	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/rollkit/go-da"
+	"github.com/rollkit/go-da/proxy"
+)
+
+// NubitDABackend implements the DA integration with Nubit DA layer
+type NubitDABackend struct {
+	dataCommitteeContract *polygondatacommittee.PolygondatacommitteeXlayer
+	client                da.DA
+	config                *Config
+	ns                    da.Namespace
+	privKey               *ecdsa.PrivateKey
+	commitTime            time.Time
+	batchesDataCache      [][]byte
+	batchesDataSize       uint64
+}
+
+// NewNubitDABackend is the factory method to create a new instance of NubitDABackend
+func NewNubitDABackend(
+	l1RPCURL string,
+	dataCommitteeAddr common.Address,
+	privKey *ecdsa.PrivateKey,
+	cfg *Config,
+) (*NubitDABackend, error) {
+	ethClient, err := ethclient.Dial(l1RPCURL)
+	if err != nil {
+		log.Errorf("error connecting to %s: %+v", l1RPCURL, err)
+		return nil, err
+	}
+
+	log.Infof("NubitDABackend config: %#v ", cfg)
+	cn, err := proxy.NewClient(cfg.NubitRpcURL, cfg.NubitAuthKey)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: Check if name byte array requires zero padding
+	name, err := hex.DecodeString(cfg.NubitNamespace)
+	if err != nil {
+		log.Errorf("error decoding NubitDA namespace config: %+v", err)
+		return nil, err
+	}
+	dataCommittee, err := polygondatacommittee.NewPolygondatacommitteeXlayer(dataCommitteeAddr, ethClient)
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("NubitDABackend namespace: %s ", string(name))
+
+	return &NubitDABackend{
+		dataCommitteeContract: dataCommittee,
+		config:                cfg,
+		privKey:               privKey,
+		ns:                    name,
+		client:                cn,
+		commitTime:            time.Now(),
+		batchesDataCache:      [][]byte{},
+		batchesDataSize:       0,
+	}, nil
+}
+
+// Init initializes the NubitDA backend
+func (backend *NubitDABackend) Init() error {
+	return nil
+}
+
+// PostSequence sends the sequence data to the data availability backend, and returns the dataAvailabilityMessage
+// as expected by the contract
+func (backend *NubitDABackend) PostSequence(ctx context.Context, batchesData [][]byte) ([]byte, error) {
+	encodedData, err := MarshalBatchData(batchesData)
+	if err != nil {
+		log.Errorf("Marshal batch data failed: %s", err)
+		return nil, err
+	}
+
+	// Add to batches data cache
+	backend.batchesDataCache = append(backend.batchesDataCache, encodedData)
+	backend.batchesDataSize += uint64(len(encodedData))
+	if backend.batchesDataSize < backend.config.NubitMaxBatchesSize {
+		log.Infof("Added batches data to NubitDABackend cache, current length: %+v", len(encodedData))
+		return nil, nil
+	}
+	if time.Since(backend.commitTime) < 12*time.Second {
+		time.Sleep(time.Since(backend.commitTime))
+	}
+
+	data, err := MarshalBatchData(backend.batchesDataCache)
+	if err != nil {
+		log.Errorf("Marshal batch data failed: %s", err)
+		return nil, err
+	}
+	id, err := backend.client.Submit(ctx, [][]byte{data}, -1, backend.ns)
+	if err != nil {
+		log.Errorf("Submit batch data with NubitDA client failed: %s", err)
+		return nil, err
+	}
+	log.Infof("Data submitted to Nubit DA: %d bytes against namespace %v sent with id %#x", len(backend.batchesDataCache), backend.ns, id)
+
+	// Reset batches data cache and DA commit time
+	backend.commitTime = time.Now()
+	backend.batchesDataCache = [][]byte{}
+	backend.batchesDataSize = 0
+
+	// Get proof
+	tries := uint64(0)
+	posted := false
+	for tries < backend.config.NubitGetProofMaxRetry {
+		dataProof, err := backend.client.GetProofs(ctx, id, backend.ns)
+		if err != nil {
+			log.Infof("Proof not available: %s", err)
+		}
+		if len(dataProof) > 0 {
+			log.Infof("Data proof from Nubit DA received: %+v", dataProof)
+			posted = true
+			break
+		}
+
+		tries += 1
+		time.Sleep(backend.config.NubitGetProofWaitPeriod)
+	}
+	if !posted {
+		log.Errorf("Get blob proof on Nubit DA failed: %s", err)
+		return nil, err
+	}
+
+	// // TODO: use bridge API data
+	// batchDAData := BatchDAData{ID: id}
+	// log.Infof("Nubit DA data ID: %+v", batchDAData)
+	// returnData, err := batchDAData.Encode()
+	// if err != nil {
+	// 	return nil, fmt.Errorf("Encode batch data failed: %w", err)
+	// }
+
+	// Sign sequence
+	sequence := daTypes.Sequence{}
+	for _, seq := range batchesData {
+		sequence = append(sequence, seq)
+	}
+	signedSequence, err := sequence.Sign(backend.privKey)
+	if err != nil {
+		log.Errorf("Failed to sign sequence with pk: %v", err)
+		return nil, err
+	}
+	signature := append(sequence.HashToSign(), signedSequence.Signature...)
+
+	return signature, nil
+}
+
+// GetSequence gets the sequence data from NubitDA layer
+func (backend *NubitDABackend) GetSequence(ctx context.Context, batchHashes []common.Hash, dataAvailabilityMessage []byte) ([][]byte, error) {
+	batchDAData := BatchDAData{}
+	err := batchDAData.Decode(dataAvailabilityMessage)
+	if err != nil {
+		log.Errorf("🏆    NubitDABackend.GetSequence.Decode:%s", err)
+		return nil, err
+	}
+	log.Infof("🏆     Nubit GetSequence batchDAData:%+v", batchDAData)
+	blob, err := backend.client.Get(ctx, batchDAData.ID, backend.ns)
+	if err != nil {
+		log.Errorf("🏆    NubitDABackend.GetSequence.Blob.Get:%s", err)
+		return nil, err
+	}
+	log.Infof("🏆     Nubit GetSequence blob.data:%+v", len(blob))
+
+	return blob, nil
+}

--- a/dataavailability/nubit/backend_test.go
+++ b/dataavailability/nubit/backend_test.go
@@ -1,0 +1,30 @@
+package nubit
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/rollkit/go-da/proxy"
+)
+
+func NewNubitDABackendTest(url string, authKey string, pk *ecdsa.PrivateKey) (*NubitDABackend, error) {
+	cn, err := proxy.NewClient(url, authKey)
+	if err != nil || cn == nil {
+		return nil, err
+	}
+
+	name, err := hex.DecodeString("00000000000000000000000000000000000000000000706f6c79676f6e")
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Nubit Namespace: %s ", string(name))
+	return &NubitDABackend{
+		ns:         name,
+		client:     cn,
+		privKey:    pk,
+		commitTime: time.Now(),
+	}, nil
+}

--- a/dataavailability/nubit/chain.go
+++ b/dataavailability/nubit/chain.go
@@ -1,0 +1,41 @@
+package nubit
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+// MarshalBatchData packs the batch data into ABI-encoded byte array
+func MarshalBatchData(batchData [][]byte) ([]byte, error) {
+	byteArrayType, _ := abi.NewType("bytes[]", "", nil)
+	args := abi.Arguments{
+		{Type: byteArrayType, Name: "batchData"},
+	}
+	res, err := args.Pack(&batchData)
+	if err != nil {
+		return make([]byte, 0), fmt.Errorf("cannot pack batchData:%w", err)
+	}
+	return res, nil
+}
+
+// UnmarshalBatchData unpacks the ABI-encoded byte array into batch data
+func UnmarshalBatchData(encodedData []byte) ([][]byte, error) {
+	byteArrayType, _ := abi.NewType("bytes[]", "", nil)
+	args := abi.Arguments{
+		{Type: byteArrayType, Name: "batchData"},
+	}
+	res, err := args.Unpack(encodedData)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unpack batchData: %w", err)
+	}
+	batchData := make([][]byte, len(res))
+	for i, v := range res {
+		byteSlice, ok := v.([]byte)
+		if !ok {
+			return nil, fmt.Errorf("element at index %d is not a []byte", i)
+		}
+		batchData[i] = byteSlice
+	}
+	return batchData, nil
+}

--- a/dataavailability/nubit/config.go
+++ b/dataavailability/nubit/config.go
@@ -1,0 +1,14 @@
+package nubit
+
+import "time"
+
+// Config is the NubitDA backend configurations
+type Config struct {
+	NubitRpcURL             string        `mapstructure:"NubitRpcURL"`
+	NubitModularAppName     string        `mapstructure:"NubitModularAppName"`
+	NubitAuthKey            string        `mapstructure:"NubitAuthKey"`
+	NubitNamespace          string        `mapstructure:"NubitNamespace"`
+	NubitMaxBatchesSize     uint64        `mapstructure:"NubitMaxBatchesSize"`
+	NubitGetProofMaxRetry   uint64        `mapstructure:"NubitGetProofMaxRetry"`
+	NubitGetProofWaitPeriod time.Duration `mapstructure:"NubitGetProofWaitPeriod"`
+}

--- a/dataavailability/nubit/nubit_test.go
+++ b/dataavailability/nubit/nubit_test.go
@@ -1,0 +1,37 @@
+package nubit
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreDetailsOnChain(t *testing.T) {
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nubit, err := NewNubitDABackendTest("http://127.0.0.1:26658", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.DAMv0s7915Ahx-kDFSzDT1ATz4Q9WwktWcHmjp7_99Q", pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var returnData []byte
+	for i := 0; i < 10; i++ {
+		txs := []byte("test txs")
+		r, err := nubit.PostSequence(context.TODO(), [][]byte{txs})
+		require.NoError(t, err)
+		if r != nil {
+			returnData = r
+		}
+		time.Sleep(600 * time.Millisecond)
+	}
+
+	_, err = nubit.GetSequence(context.TODO(), []common.Hash{}, returnData)
+	require.NoError(t, err)
+}

--- a/dataavailability/nubit/types.go
+++ b/dataavailability/nubit/types.go
@@ -1,0 +1,42 @@
+package nubit
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/rollkit/go-da"
+)
+
+// BatchDAData contains the batch information on NubitDA
+type BatchDAData struct {
+	ID []da.ID `json:"id,omitempty"`
+}
+
+// Encode encodes the BatchDAData into ABI-encoded bytes
+func (b *BatchDAData) Encode() ([]byte, error) {
+	return json.Marshal(b)
+}
+
+// Decode decodes the ABI-encoded bytes into BatchDAData
+func (b *BatchDAData) Decode(data []byte) error {
+	return json.Unmarshal(data, &b)
+}
+
+// IsEmpty checks i fthe BatchDAData is empty
+func (b *BatchDAData) IsEmpty() bool {
+	return reflect.DeepEqual(b, BatchDAData{})
+}
+
+// DataCommitteeMember represents a member of the Data Committee
+type DataCommitteeMember struct {
+	Addr common.Address
+	URL  string
+}
+
+// DataCommittee represents a specific committee
+type DataCommittee struct {
+	AddressesHash      common.Hash
+	Members            []DataCommitteeMember
+	RequiredSignatures uint64
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/0xPolygonHermez/zkevm-node
 
-go 1.21
+go 1.21.1
+
+toolchain go1.22.2
 
 require (
 	github.com/0xPolygonHermez/zkevm-data-streamer v0.2.3-RC4
@@ -23,7 +25,7 @@ require (
 	github.com/rubenv/sql-migrate v1.6.1
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/viper v1.18.2
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.9.0
 	github.com/umbracle/ethgo v0.1.4-0.20230712173909-df37dddf16f0
 	github.com/urfave/cli/v2 v2.26.0
 	go.uber.org/zap v1.26.0
@@ -68,6 +70,7 @@ require (
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
+	github.com/filecoin-project/go-jsonrpc v0.3.1 // indirect
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff // indirect
@@ -94,6 +97,7 @@ require (
 	github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
+	github.com/ipfs/go-log/v2 v2.0.8 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -147,7 +151,7 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/status-im/keycard-go v0.2.0 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
@@ -158,12 +162,14 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
+	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.17.0 // indirect
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
@@ -184,6 +190,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/nacos-group/nacos-sdk-go v1.1.4
 	github.com/prometheus/client_golang v1.18.0
+	github.com/rollkit/go-da v0.5.0
 	github.com/segmentio/kafka-go v0.4.47
 	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3
 	golang.org/x/time v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/filecoin-project/go-jsonrpc v0.3.1 h1:qwvAUc5VwAkooquKJmfz9R2+F8znhiqcNHYjEp/NM10=
+github.com/filecoin-project/go-jsonrpc v0.3.1/go.mod h1:jBSvPTl8V1N7gSTuCR4bis8wnQnIjHbRPpROol6iQKM=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -435,6 +437,8 @@ github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/C
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
 github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/ipfs/go-log/v2 v2.0.8 h1:3b3YNopMHlj4AvyhWAx0pDxqSQWYi4/WuWO7yRV6/Qg=
+github.com/ipfs/go-log/v2 v2.0.8/go.mod h1:eZs4Xt4ZUJQFM3DlanGhy7TkwwawCZcSByscwkWG+dw=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/jade v1.1.3/go.mod h1:H/geBymxJhShH5kecoiOCSssPX7QWYH7UaeZTSWddIk=
@@ -701,6 +705,8 @@ github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rollkit/go-da v0.5.0 h1:sQpZricNS+2TLx3HMjNWhtRfqtvVC/U4pWHpfUz3eN4=
+github.com/rollkit/go-da v0.5.0/go.mod h1:VsUeAoPvKl4Y8wWguu/VibscYiFFePkkrvZWyTjZHww=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
@@ -775,8 +781,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -787,8 +794,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
@@ -870,6 +878,8 @@ go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
+go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
+go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -887,6 +897,7 @@ go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9E
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
+go.uber.org/zap v1.14.1/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.15.0/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
@@ -1226,6 +1237,8 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=


### PR DESCRIPTION
## Summary

- Initial development on NubitDA integration as X Layer validium node's offchain data availability provider
- Implementation of Nubit's core team development on Polygon's cdk-validium-node integration demo: https://github.com/RiemaLabs/cdk-validium-node]
- Note that the integration of the NubitDA backend contains a few key refactors and code clean ups
- This PR is incomplete and it is a draft for reference

## Pending issue on NubitDA backend
- There is an issue on GetSequence pipeline. Data availability message has since been changed to be the sequence signature, decoding of the data availability message bytes is incorrect (Code ref: https://github.com/RiemaLabs/cdk-validium-node/blob/develop/dataavailability/nubit/backend.go#L180-L199)
- In PostSequence pipeline, returnData containing the NubitDA blob's ID is never handled (Code ref: https://github.com/RiemaLabs/cdk-validium-node/blob/fc42ce25c148471c8ee3638ef9e6a25e246caa44/dataavailability/nubit/backend.go#L177)

## Refactor changes
- Revert back to the original PostSequence interface - theres no need to change the interface since sequences are signed by the sequence sender private key. Also, we should maintain interfaces for backwards compatibility
- Add configurable callbacks for blob confirmation on NubitDA layer in post sequence pipeline
- Minor fixes - code cleanups, better error handling


